### PR TITLE
bookmarks/list: support skipping known highlights

### DIFF
--- a/instapaper/bookmarks.go
+++ b/instapaper/bookmarks.go
@@ -87,6 +87,10 @@ func (svc *BookmarkService) List(p BookmarkListRequestParams) (*BookmarkListResp
 	}
 	params.Set("highlights", strings.Join(highlightList, "-"))
 
+	if p.Folder != "" {
+		params.Set("folder_id", p.Folder)
+	}
+
 	res, err := svc.Client.Call("/bookmarks/list", params)
 	if err != nil {
 		return &BookmarkListResponse{}, err

--- a/instapaper/bookmarks.go
+++ b/instapaper/bookmarks.go
@@ -36,6 +36,7 @@ type BookmarkListResponse struct {
 type BookmarkListRequestParams struct {
 	Limit           int
 	Skip            []Bookmark
+	SkipHighlights  []Highlight
 	CustomHaveParam string
 	Folder          string
 }
@@ -79,6 +80,12 @@ func (svc *BookmarkService) List(p BookmarkListRequestParams) (*BookmarkListResp
 		}
 		params.Set("have", strings.Join(haveList, ","))
 	}
+
+	var highlightList []string
+	for _, highlight := range p.SkipHighlights {
+		highlightList = append(highlightList, strconv.Itoa(highlight.ID))
+	}
+	params.Set("highlights", strings.Join(highlightList, "-"))
 
 	res, err := svc.Client.Call("/bookmarks/list", params)
 	if err != nil {


### PR DESCRIPTION
The instapaper API accepts a "-"-delimited list of highlight IDs
that it will filter out of the response (similar to the "have"
parameter but without the special hash checking functionality).

Expose this as a slice of highlights.